### PR TITLE
Fix and enhance maintanence scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ define get_cur_rel_ver
 $(shell grep "^version = [0-9]\+\.[0-9]\+" setup.cfg | cut -d' ' -f3)
 endef
 
+
 release: distcheck
 	@sh -e scripts/make_release.sh
 	@echo
@@ -42,3 +43,13 @@ release: distcheck
 	@echo "twine-3 upload -u tkdchen release/krbcontext-$(call get_cur_rel_ver).tar.gz"
 	@echo "Push documentation to tkdchen.github.io"
 .PHONY: release
+
+
+publishpackages:
+	@sh -e scripts/publish-packages.sh
+.PHONY: publishpackages
+
+
+publishdoc: doc
+	@sh -e scripts/publish-doc.sh
+.PHONY: publishdoc

--- a/scripts/make_release.sh
+++ b/scripts/make_release.sh
@@ -5,9 +5,11 @@
 cd $(dirname $(realpath $0))/..
 
 release_dir=release
-test -e ${release_dir} || mkdir ${release_dir}
-
 specfile=python-krbcontext.spec
+
+test -e ${release_dir} && rm -rf ${release_dir}
+mkdir ${release_dir}
+
 
 name=$(python -c "import ConfigParser; cfg=ConfigParser.RawConfigParser(); cfg.read('setup.cfg'); print(cfg.get('package', 'name'))")
 rel_ver=$(python -c "import ConfigParser; cfg=ConfigParser.RawConfigParser(); cfg.read('setup.cfg'); print(float(cfg.get('package', 'version'))+0.1)")
@@ -44,8 +46,11 @@ function update_spec_changelog
     rm .release-changelog
 }
 
+
 function gather_release_artifacts
 {
+    # Gather tarball and RPM packages into release directory.
+
     cp dist/${name}-${rel_ver}.tar.gz ${release_dir}
 
     local -r srpm_nvr=$(rpm -q --qf "%{NVR}\n" --specfile ${specfile} | head -n 1)
@@ -56,8 +61,6 @@ function gather_release_artifacts
         | while read -r rpm_nvra arch; do
             cp dist/${arch}/${rpm_nvra}.rpm ${release_dir}
         done
-
-    cp -r docs/build/html/ ${release_dir}/docs
 }
 
 bump_version

--- a/scripts/publish-doc.sh
+++ b/scripts/publish-doc.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# `make doc' is required to run in advance.
+
+cd "$(dirname $(realpath $0))/../"
+
+author=$(python -c "import ConfigParser; cfg=ConfigParser.RawConfigParser(); cfg.read('setup.cfg'); print(cfg.get('package', 'author'))")
+email=$(python -c "import ConfigParser; cfg=ConfigParser.RawConfigParser(); cfg.read('setup.cfg'); print(cfg.get('package', 'email'))")
+rel_ver=$(python -c "import ConfigParser; cfg=ConfigParser.RawConfigParser(); cfg.read('setup.cfg'); print(cfg.get('package', 'version'))")
+
+RELEASE_DIR="$(realpath release)"
+mkdir ${RELEASE_DIR}/docs
+cp -r docs/build/html/* ${RELEASE_DIR}/docs/
+
+# All rest things happen in release directory.
+
+cd "${RELEASE_DIR}"
+
+git clone git@github.com:krbcontext/krbcontext.github.io.git
+
+cp -r docs/* krbcontext.github.io/
+
+cd krbcontext.github.io/
+git config user.name "${author}"
+git config user.email "${email}"
+
+git add *
+git commit -s -m "Update doc for ${rel_ver} release"
+git push origin HEAD:master

--- a/scripts/publish-packages.sh
+++ b/scripts/publish-packages.sh
@@ -3,11 +3,12 @@
 cd "$(dirname $(realpath $0))/../"
 
 RELEASE_DIR="$(realpath release)"
+SPEC=python-krbcontext.spec
 
 name=$(python -c "import ConfigParser; cfg=ConfigParser.RawConfigParser(); cfg.read('setup.cfg'); print(cfg.get('package', 'name'))")
 rel_ver=$(python -c "import ConfigParser; cfg=ConfigParser.RawConfigParser(); cfg.read('setup.cfg'); print(cfg.get('package', 'version'))")
 
 twine upload -u tkdchen "${RELEASE_DIR}/${name}-${rel_ver}.tar.gz"
 
-srpm_nvr=$(rpm -q --qf "%{NVR}\n" --specfile ${specfile} | head -n 1)
+srpm_nvr=$(rpm -q --qf "%{NVR}\n" --specfile ${SPEC} | head -n 1)
 copr-cli --config ~/.config/copr-fedora build cqi/python-krbcontext "${RELEASE_DIR}/${srpm_nvr}.src.rpm"


### PR DESCRIPTION
Add new script publish-doc.sh. It requires to build documentation with
`make doc' in advance. Built documentation is not gathered into release
directory in make_release.sh.

Fix script publish-packages.sh, add missing SPEC file.

Each time to make a release, delete whole release directory.

Be able to publish packages and documentation from Makefile.

Signed-off-by: Chenxiong Qi <qcxhome@gmail.com>