### PR TITLE
Fix renewing expired FILE ccache

### DIFF
--- a/test/test_krbcontext.py
+++ b/test/test_krbcontext.py
@@ -103,17 +103,18 @@ class TestInitWithKeytab(unittest.TestCase):
         self.Lock.start()
 
         # No need to create a real temp file for tests
-        self.tmp_ccache = 'tmp-ccache'
-        self.mkstemp = patch('tempfile.mkstemp',
-                             return_value=(1, self.tmp_ccache))
-        self.mkstemp.start()
+        self.tmp_dir = '/tmp/test-krbcontext'
+        self.tmp_ccache = os.path.join(self.tmp_dir, 'ccache')
+        self.mkdtemp = patch('tempfile.mkdtemp',
+                             return_value=self.tmp_dir)
+        self.mkdtemp.start()
 
         self.os_close = patch('os.close')
         self.os_close.start()
 
     def tearDown(self):
         self.os_close.stop()
-        self.mkstemp.stop()
+        self.mkdtemp.stop()
         self.Lock.stop()
 
     @patch('gssapi.creds.Credentials')


### PR DESCRIPTION
Renewing expired FILE ccache didn't work because krbcontext created an
empty file for the ccache, but kerberos considered an empty file
invalid.

Fix this by creating a temporary directory and letting kerberos create
the ccache file by itself (which is a perfectly valid scenario). Also
add cleanup for the temporary dir and fix the directory naming.

Fixes #23