### PR TITLE
Use set_default when storing credentials

### DIFF
--- a/krbcontext/context.py
+++ b/krbcontext/context.py
@@ -171,7 +171,8 @@ class krbContext(object):
                 # store parameter passed to ``creds.store``.
                 if self._cleaned_options['ccache'] != DEFAULT_CCACHE:
                     _store = {'ccache': store['ccache']}
-                creds.store(usage='initiate', store=_store, overwrite=True)
+                creds.store(usage='initiate', store=_store, set_default=True,
+                            overwrite=True)
             finally:
                 shutil.rmtree(temp_directory, ignore_errors=True)
 

--- a/test/test_krbcontext.py
+++ b/test/test_krbcontext.py
@@ -143,6 +143,7 @@ class TestInitWithKeytab(unittest.TestCase):
         Credentials.return_value.store.assert_called_once_with(
             store=None,
             usage='initiate',
+            set_default=True,
             overwrite=True)
 
     @patch('gssapi.creds.Credentials')
@@ -164,11 +165,13 @@ class TestInitWithKeytab(unittest.TestCase):
                  store={'client_keytab': keytab}),
             call(usage='initiate', name=self.princ_name,
                  store={'ccache': self.tmp_ccache, 'client_keytab': keytab}),
-            call().store(usage='initiate', store=None, overwrite=True),
+            call().store(usage='initiate', store=None,
+                         set_default=True, overwrite=True),
         ])
         Credentials.return_value.store.assert_called_once_with(
             store=None,
             usage='initiate',
+            set_default=True,
             overwrite=True)
 
     @patch('gssapi.creds.Credentials')
@@ -191,6 +194,7 @@ class TestInitWithKeytab(unittest.TestCase):
         Credentials.return_value.store.assert_called_once_with(
             store={'ccache': ccache},
             usage='initiate',
+            set_default=True,
             overwrite=True)
 
     @patch('gssapi.creds.Credentials')
@@ -216,6 +220,7 @@ class TestInitWithKeytab(unittest.TestCase):
         Credentials.return_value.store.assert_called_once_with(
             store={'ccache': ccache},
             usage='initiate',
+            set_default=True,
             overwrite=True)
 
 


### PR DESCRIPTION
Storing non-default credentials into default ccache is not supported and
causes errors like this:
```
gssapi.raw.misc.GSSError: Major (851968): Unspecified GSS failure.  Minor code may provide more information, Minor (2249944339): Storing of non-default credentials is not supported by the mechanism
```